### PR TITLE
Conditional create of test db

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ env:
 
 before_install:
   # Create mautictest database
-  - mysql -e 'CREATE DATABASE mautictest;'
+  - if [[ $TC == 'unit' ]]; then mysql -e 'CREATE DATABASE mautictest;'; fi
 
   # turn off XDebug
   - phpenv config-rm xdebug.ini || return


### PR DESCRIPTION
The UI tests already create the database in their own script, so no need to do it explicitly here in Travis.