### PR TITLE
Initial fixture reload between scenarios with logging

### DIFF
--- a/tests/TestHelpers/SetupHelper.php
+++ b/tests/TestHelpers/SetupHelper.php
@@ -73,9 +73,22 @@ class SetupHelper {
     }
 
     /**
-     * invokes a Mautic command
+     * (Re)load the test fixtures (test database data)
      *
-     * @param array $args anything behind "mauticc".
+     * @param string $mauticPath
+     * @return string[] associated array with "code", "stdOut", "stdErr"
+     */
+    public static function loadTestFixtures($mauticPath) {
+        exec('mysql -u travis -e "set global foreign_key_checks=0;"');
+        $output = self::runMauticCommand(['doctrine:fixtures:load', '--env=test', '--no-interaction'], $mauticPath);
+        exec('mysql -u travis -e "set global foreign_key_checks=1;"');
+        return $output;
+    }
+
+    /**
+     * invokes a Mautic console command
+     *
+     * @param array $args anything behind "app/console".
      * For example: "user:add"
      * @param string $mauticPath
      * @param string $escaping
@@ -98,7 +111,7 @@ class SetupHelper {
             2 => ['pipe', 'w'],
         ];
         $process = proc_open(
-            'php console.php ' . $args, $descriptor, $pipes, $mauticPath
+            'php app/console ' . $args, $descriptor, $pipes, $mauticPath
         );
         $lastStdOut = stream_get_contents($pipes[1]);
         $lastStdErr = stream_get_contents($pipes[2]);

--- a/tests/ui/features/bootstrap/BasicStructure.php
+++ b/tests/ui/features/bootstrap/BasicStructure.php
@@ -149,6 +149,8 @@ trait BasicStructure
         $this->regularUserName = (string)$suiteParameters['regularUserName'];
         $this->regularUserPassword = (string)$suiteParameters['regularUserPassword'];
         $this->mauticPath = rtrim($suiteParameters['mauticPath'], '/') . '/';
+        $output = SetupHelper::loadTestFixtures($this->mauticPath);
+        echo $output['stdOut'];
     }
 
     /** @AfterScenario */

--- a/tests/ui/features/bootstrap/BasicStructure.php
+++ b/tests/ui/features/bootstrap/BasicStructure.php
@@ -34,7 +34,7 @@ trait BasicStructure
      * @var array
      */
     private $createdUsers = array();
-    private $mauticPath;
+    private $mauticPath = null;
 
     /**
      * @Given I am logged in as admin
@@ -137,7 +137,23 @@ trait BasicStructure
             "email" => $email
         ];
     }
-    /** @BeforeScenario */
+
+    /**
+     * @BeforeScenario @fixtures
+     */
+    public function setUpTestFixtures(BeforeScenarioScope $scope)
+    {
+        if (is_null($this->mauticPath)) {
+            $suiteParameters = $scope->getEnvironment()->getSuite()->getSettings() ['context'] ['parameters'];
+            $this->mauticPath = rtrim($suiteParameters['mauticPath'], '/') . '/';
+        }
+
+        SetupHelper::loadTestFixtures($this->mauticPath);
+    }
+
+    /**
+     * @BeforeScenario
+     */
     public function setUpScenarioGetRegularUsers(BeforeScenarioScope $scope)
     {
         $suiteParameters = $scope->getEnvironment()->getSuite()->getSettings() ['context'] ['parameters'];
@@ -148,12 +164,14 @@ trait BasicStructure
         $this->regularUserNames = explode(",", $suiteParameters['regularUserNames']);
         $this->regularUserName = (string)$suiteParameters['regularUserName'];
         $this->regularUserPassword = (string)$suiteParameters['regularUserPassword'];
-        $this->mauticPath = rtrim($suiteParameters['mauticPath'], '/') . '/';
-        $output = SetupHelper::loadTestFixtures($this->mauticPath);
-        echo $output['stdOut'];
+        if (is_null($this->mauticPath)) {
+            $this->mauticPath = rtrim($suiteParameters['mauticPath'], '/') . '/';
+        }
     }
 
-    /** @AfterScenario */
+    /**
+     * @AfterScenario
+     */
     public function tearDownScenarioDeleteCreatedUsers(AfterScenarioScope $scope)
     {
         foreach ($this->getCreatedUserNames() as $user) {


### PR DESCRIPTION
Reload/reset the fixtures (database data) at the start of every scenario.

Note: It takes a significant amount of time to do this. Let's see what the Travis run time is.