### PR TITLE
Add new contact

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -58,6 +58,16 @@ matrix:
         sauce_connect: true
 
     - php: 7.1
+      env: TC=selenium BROWSER="chrome" BROWSER_VERSION="latest" BEHAT_SUITE="contacts" PLATFORM="Windows 10"
+      addons:
+        sauce_connect: true
+
+    - php: 7.1
       env: TC=selenium BROWSER="firefox" BROWSER_VERSION="47.0" BEHAT_SUITE="basic" PLATFORM="Windows 10"
+      addons:
+        sauce_connect: true
+
+    - php: 7.1
+      env: TC=selenium BROWSER="firefox" BROWSER_VERSION="47.0" BEHAT_SUITE="contacts" PLATFORM="Windows 10"
       addons:
         sauce_connect: true

--- a/tests/ui/config/behat.yml
+++ b/tests/ui/config/behat.yml
@@ -51,3 +51,4 @@ default:
         - FeatureContext:
         - LoginContext:
         - ContactsContext:
+        - NewContactContext:

--- a/tests/ui/features/basic/account.feature
+++ b/tests/ui/features/basic/account.feature
@@ -7,7 +7,7 @@ Feature: account
   Scenario: change passwword
     Given I am logged in as sales
     And I select the Account topbar entry
-    Then I should be redirected to a page with the title "Account | Mautic"
+    And I am redirected to a page with the title "Account | Mautic"
     When I set account password to "qwe@478!"
     And I apply the account changes
     And I logout
@@ -19,7 +19,7 @@ Feature: account
   Scenario: input too short a password
     Given I am logged in as sales
     And I select the Account topbar entry
-    Then I should be redirected to a page with the title "Account | Mautic"
+    And I am redirected to a page with the title "Account | Mautic"
     When I set account password to "short"
     And I apply the account changes
     Then near the password field a message should be displayed "Password must be at least 6 characters"
@@ -27,7 +27,7 @@ Feature: account
   Scenario: input non-matching password and confirm password
     Given I am logged in as sales
     And I select the Account topbar entry
-    Then I should be redirected to a page with the title "Account | Mautic"
+    And I am redirected to a page with the title "Account | Mautic"
     When I set account password to "something" and confirm password to "different"
     And I apply the account changes
     Then near the password field a message should be displayed "Passwords do not match"
@@ -36,7 +36,7 @@ Feature: account
   Scenario Outline: modify display name of a user
     Given I am logged in as sales
     And I select the Account topbar entry
-    Then I should be redirected to a page with the title "Account | Mautic"
+    And I am redirected to a page with the title "Account | Mautic"
     When I set account first name to <first_name>
     And I set account last name to <last_name>
     And I apply the account changes

--- a/tests/ui/features/basic/login.feature
+++ b/tests/ui/features/basic/login.feature
@@ -1,11 +1,11 @@
-Feature: login
+Feature: login and out
   In order to access Mautic securely
   As an authorised user
   I want to be able to authenticate myself with a username and password
-  And I want to be able to logout to secure my account
+  I want to be able to logout to secure my account
 
   Scenario: simple user login to the sales account
-    Given I am logged in as sales
+    When I am logged in as sales
     Then I should be redirected to a page with the title "Dashboard | Mautic"
     And the user display name is "Sales User"
     When I logout

--- a/tests/ui/features/bootstrap/AccountContext.php
+++ b/tests/ui/features/bootstrap/AccountContext.php
@@ -90,7 +90,7 @@ class AccountContext extends RawMinkContext implements Context
      */
     public function iApplyTheAccountChanges()
     {
-        $this->accountPage->applyAccountChanges();
+        $this->accountPage->applyChanges();
     }
 
     /**

--- a/tests/ui/features/bootstrap/ContactsContext.php
+++ b/tests/ui/features/bootstrap/ContactsContext.php
@@ -43,4 +43,13 @@ class ContactsContext extends RawMinkContext implements Context
         $this->visitPath($this->contactsPage->getPagePath());
         $this->contactsPage->waitForOutstandingAjaxCalls($this->getSession());
     }
+
+    /**
+     * @Given /^I select the new contact button$/
+     */
+    public function iSelectTheNewContactButton()
+    {
+        $this->contactsPage->selectNewContactButton();
+        $this->contactsPage->waitForOutstandingAjaxCalls($this->getSession());
+    }
 }

--- a/tests/ui/features/bootstrap/FeatureContext.php
+++ b/tests/ui/features/bootstrap/FeatureContext.php
@@ -34,7 +34,7 @@ class FeatureContext extends RawMinkContext implements Context
     }
 
     /**
-     * @Then I should be redirected to a page with the title :title
+     * @Then /^I (?:should be|am) redirected to a page with the title "([^"]*)"$/
      */
     public function iShouldBeRedirectedToAPageWithTheTitle($title)
     {

--- a/tests/ui/features/bootstrap/NewContactContext.php
+++ b/tests/ui/features/bootstrap/NewContactContext.php
@@ -1,0 +1,46 @@
+<?php
+
+/*
+ * @copyright   2014 Mautic Contributors. All rights reserved
+ * @author      Mautic
+ *
+ * @link        http://mautic.org
+ *
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+use Behat\Behat\Context\Context;
+use Behat\MinkExtension\Context\RawMinkContext;
+use Page\NewContactPage;
+
+require_once 'bootstrap.php';
+
+/**
+ * New Contact context.
+ */
+class NewContactContext extends RawMinkContext implements Context
+{
+    private $newContactPage;
+
+    public function __construct(NewContactPage $page)
+    {
+        $this->newContactPage = $page;
+    }
+
+    /**
+     * @Given I am on the new contact page
+     */
+    public function iAmOnTheNewContactPage()
+    {
+        $this->newContactPage->open();
+    }
+
+    /**
+     * @Given I go to the new contact page
+     */
+    public function iGoToTheNewContactPage()
+    {
+        $this->visitPath($this->newContactPage->getPagePath());
+        $this->newContactPage->waitForOutstandingAjaxCalls($this->getSession());
+    }
+}

--- a/tests/ui/features/bootstrap/NewContactContext.php
+++ b/tests/ui/features/bootstrap/NewContactContext.php
@@ -43,4 +43,88 @@ class NewContactContext extends RawMinkContext implements Context
         $this->visitPath($this->newContactPage->getPagePath());
         $this->newContactPage->waitForOutstandingAjaxCalls($this->getSession());
     }
+
+    /**
+     * @When /^I set contact title to (.*)$/
+     */
+    public function iSetContactTitleTo($title)
+    {
+        $this->newContactPage->setTitle($title);
+    }
+
+    /**
+     * @Given /^I set contact first name to (.*)$/
+     */
+    public function iSetContactFirstNameTo($firstName)
+    {
+        $this->newContactPage->setFirstName($firstName);
+    }
+
+    /**
+     * @Given /^I set contact last name to (.*)$/
+     */
+    public function iSetContactLastNameTo($lastName)
+    {
+        $this->newContactPage->setLastName($lastName);
+    }
+
+    /**
+     * @Given /^I set contact email to (.*)$/
+     */
+    public function iSetContactEmailTo($email)
+    {
+        $this->newContactPage->setEmail($email);
+    }
+
+    /**
+     * @Given /^I apply the contact changes$/
+     */
+    public function iApplyTheContactChanges()
+    {
+        $this->newContactPage->applyChanges();
+    }
+
+    /**
+     * @Then /^the contact title is (.*)$/
+     */
+    public function theContactTitleIs($title)
+    {
+        PHPUnit_Framework_Assert::assertEquals(
+            $title,
+            $this->newContactPage->getTitle()
+        );
+    }
+
+    /**
+     * @Given /^the contact first name is (.*)$/
+     */
+    public function theContactFirstNameIs($firstName)
+    {
+        PHPUnit_Framework_Assert::assertEquals(
+            $firstName,
+            $this->newContactPage->getFirstName()
+        );
+    }
+
+    /**
+     * @Given /^the contact last name is (.*)$/
+     */
+    public function theContactLastNameIs($lastName)
+    {
+        PHPUnit_Framework_Assert::assertEquals(
+            $lastName,
+            $this->newContactPage->getLastName()
+        );
+    }
+
+    /**
+     * @Given /^the contact email is (.*)$/
+     */
+    public function theContactEmailIs($email)
+    {
+        PHPUnit_Framework_Assert::assertEquals(
+            $email,
+            $this->newContactPage->getEmail()
+        );
+    }
 }

--- a/tests/ui/features/bootstrap/NewContactContext.php
+++ b/tests/ui/features/bootstrap/NewContactContext.php
@@ -82,6 +82,7 @@ class NewContactContext extends RawMinkContext implements Context
     public function iApplyTheContactChanges()
     {
         $this->newContactPage->applyChanges();
+        $this->newContactPage->waitTillPageIsLoaded($this->getSession());
     }
 
     /**

--- a/tests/ui/features/bootstrap/NewContactContext.php
+++ b/tests/ui/features/bootstrap/NewContactContext.php
@@ -90,9 +90,11 @@ class NewContactContext extends RawMinkContext implements Context
      */
     public function theContactTitleIs($title)
     {
+        // For some titles like "Mr" the UI makes it "Mr."
+        // So for now here we just compare without any "."
         PHPUnit_Framework_Assert::assertEquals(
-            $title,
-            $this->newContactPage->getTitle()
+            trim($title, '.'),
+            trim($this->newContactPage->getTitle(), '.')
         );
     }
 

--- a/tests/ui/features/contacts/contacts.feature
+++ b/tests/ui/features/contacts/contacts.feature
@@ -21,11 +21,11 @@ Feature: contacts
     And I set contact last name to <last_name>
     And I set contact email to <email>
     And I apply the contact changes
-    Then the contact title is <title_out>
+    Then the contact title is <title>
     And the contact first name is <first_name>
     And the contact last name is <last_name>
     And the contact email is <email>
     Examples:
-      |title |first_name |last_name |email            |title_out |
-      |Prof  |Kovačević  |Müller    |kova@example.com |Prof |
-      |Mr    |Aaron      |Anderson  |aa@example.com   |Mr.  |
+      |title |first_name |last_name |email            |
+      |Prof  |Kovačević  |Müller    |kova@example.com |
+      |Mr    |Aaron      |Anderson  |aa@example.com   |

--- a/tests/ui/features/contacts/contacts.feature
+++ b/tests/ui/features/contacts/contacts.feature
@@ -1,0 +1,11 @@
+Feature: contacts
+  In order to send marketing information to people
+  As an authorised user
+  I need to record and update contact details
+
+  Scenario: add new contact
+    Given I am logged in as sales
+    And I go to the contacts page
+    And I am redirected to a page with the title "Contacts | Mautic"
+    And I select the new contact button
+    Then I am redirected to a page with the title "New Contact | Mautic"

--- a/tests/ui/features/contacts/contacts.feature
+++ b/tests/ui/features/contacts/contacts.feature
@@ -9,6 +9,7 @@ Feature: contacts
     When I login with username "admin" and password "mautic" after a redirect from the "newContact" page
     Then I should be redirected to a page with the title "New Contact | Mautic"
 
+  @fixtures
   Scenario Outline: add new contact
     Given I am logged in as sales
     And I go to the contacts page

--- a/tests/ui/features/contacts/contacts.feature
+++ b/tests/ui/features/contacts/contacts.feature
@@ -3,6 +3,12 @@ Feature: contacts
   As an authorised user
   I need to record and update contact details
 
+  Scenario: directly access the new contact page when not logged in
+    Given I go to the new contact page
+    Then I should be redirected to a page with the title "Mautic"
+    When I login with username "admin" and password "mautic" after a redirect from the "newContact" page
+    Then I should be redirected to a page with the title "New Contact | Mautic"
+
   Scenario: add new contact
     Given I am logged in as sales
     And I go to the contacts page

--- a/tests/ui/features/contacts/contacts.feature
+++ b/tests/ui/features/contacts/contacts.feature
@@ -9,9 +9,22 @@ Feature: contacts
     When I login with username "admin" and password "mautic" after a redirect from the "newContact" page
     Then I should be redirected to a page with the title "New Contact | Mautic"
 
-  Scenario: add new contact
+  Scenario Outline: add new contact
     Given I am logged in as sales
     And I go to the contacts page
     And I am redirected to a page with the title "Contacts | Mautic"
     And I select the new contact button
     Then I am redirected to a page with the title "New Contact | Mautic"
+    When I set contact title to <title>
+    And I set contact first name to <first_name>
+    And I set contact last name to <last_name>
+    And I set contact email to <email>
+    And I apply the contact changes
+    Then the contact title is <title_out>
+    And the contact first name is <first_name>
+    And the contact last name is <last_name>
+    And the contact email is <email>
+    Examples:
+      |title |first_name |last_name |email            |title_out |
+      |Prof  |Kovačević  |Müller    |kova@example.com |Prof |
+      |Mr    |Aaron      |Anderson  |aa@example.com   |Mr.  |

--- a/tests/ui/features/lib/AccountPage.php
+++ b/tests/ui/features/lib/AccountPage.php
@@ -33,14 +33,14 @@ class AccountPage extends MauticPage
     protected $applyButtonNormalId = "user_buttons_save_toolbar";
     protected $applyButtonMobileId = "user_buttons_save_toolbar_mobile";
 
-    public function setFirstName($firstname)
+    public function setFirstName($firstName)
     {
-        $this->fillField($this->firstNameInputId, $firstname);
+        $this->fillField($this->firstNameInputId, $firstName);
     }
 
-    public function setLastName($lastname)
+    public function setLastName($lastName)
     {
-        $this->fillField($this->lastNameInputId, $lastname);
+        $this->fillField($this->lastNameInputId, $lastName);
     }
 
     public function selectLanguage($language)
@@ -175,7 +175,7 @@ class AccountPage extends MauticPage
         return $lastNameElement->getValue();
     }
 
-    public function applyAccountChanges()
+    public function applyChanges()
     {
         $applyButton = $this->findById($this->applyButtonNormalId);
 

--- a/tests/ui/features/lib/ContactsPage.php
+++ b/tests/ui/features/lib/ContactsPage.php
@@ -11,6 +11,8 @@
 
 namespace Page;
 
+use SensioLabs\Behat\PageObjectExtension\PageObject\Exception\ElementNotFoundException;
+
 class ContactsPage extends MauticPage
 {
     /**
@@ -18,4 +20,21 @@ class ContactsPage extends MauticPage
      * @var string $path
      */
     protected $path = '/s/contacts';
+    protected $newContactButtonXpath = '//*[@href=\'/s/contacts/new\']';
+
+    /**
+     * Find and click the new contact button.
+     */
+    public function selectNewContactButton()
+    {
+        $newContactElement = $this->find('xpath', $this->newContactButtonXpath);
+
+        if ($newContactElement === null) {
+            throw new ElementNotFoundException(
+                "selectNewContactButton:could not find new contact button"
+            );
+        }
+
+        $newContactElement->click();
+    }
 }

--- a/tests/ui/features/lib/MauticPage.php
+++ b/tests/ui/features/lib/MauticPage.php
@@ -199,7 +199,7 @@ class MauticPage extends Page
      * @param number $timeout_msec
      * @throws \Exception
      */
-    public function waitForOutstandingAjaxCalls (Session $session, $timeout_msec = STANDARD_UI_WAIT_TIMEOUT_MILLISEC)
+    public function waitForOutstandingAjaxCalls(Session $session, $timeout_msec = STANDARD_UI_WAIT_TIMEOUT_MILLISEC)
     {
         $timeout_msec = (int) $timeout_msec;
         if ($timeout_msec <= 0) {
@@ -236,7 +236,7 @@ class MauticPage extends Page
      * @param Session $session
      * @param int $timeout_msec
      */
-    public function waitForAjaxCallsToStart (Session $session, $timeout_msec = 1000)
+    public function waitForAjaxCallsToStart(Session $session, $timeout_msec = 1000)
     {
         $timeout_msec = (int) $timeout_msec;
         if ($timeout_msec <= 0) {
@@ -258,7 +258,7 @@ class MauticPage extends Page
      * @param Session $session
      * @param int $timeout_msec
      */
-    public function waitForAjaxCallsToStartAndFinish (Session $session, $timeout_msec = STANDARD_UI_WAIT_TIMEOUT_MILLISEC)
+    public function waitForAjaxCallsToStartAndFinish(Session $session, $timeout_msec = STANDARD_UI_WAIT_TIMEOUT_MILLISEC)
     {
         $start = microtime(true);
         $this->waitForAjaxCallsToStart($session);

--- a/tests/ui/features/lib/NewContactPage.php
+++ b/tests/ui/features/lib/NewContactPage.php
@@ -11,6 +11,9 @@
 
 namespace Page;
 
+use SensioLabs\Behat\PageObjectExtension\PageObject\Exception\ElementNotFoundException;
+use WebDriver\Exception\ElementNotVisible;
+
 class NewContactPage extends MauticPage
 {
     /**
@@ -18,4 +21,121 @@ class NewContactPage extends MauticPage
      * @var string $path
      */
     protected $path = '/s/contacts/new';
+    protected $titleInputId = "lead_title";
+    protected $firstNameInputId = "lead_firstname";
+    protected $lastNameInputId = "lead_lastname";
+    protected $emailInputId = "lead_email";
+    protected $applyButtonNormalId = "lead_buttons_apply_toolbar";
+    protected $applyButtonMobileId = "lead_buttons_apply_toolbar_mobile";
+
+    public function setTitle($title)
+    {
+        $this->fillField($this->titleInputId, $title);
+    }
+
+    public function setFirstName($firstName)
+    {
+        $this->fillField($this->firstNameInputId, $firstName);
+    }
+
+    public function setLastName($lastName)
+    {
+        $this->fillField($this->lastNameInputId, $lastName);
+    }
+
+    public function setEmail($email)
+    {
+        $this->fillField($this->emailInputId, $email);
+    }
+
+    /**
+     *
+     * @return string
+     */
+    public function getTitle()
+    {
+        $titleElement = $this->findById($this->titleInputId);
+
+        if ($titleElement === null) {
+            throw new ElementNotFoundException(
+                "getTitle:could not find element"
+            );
+        }
+
+        return $titleElement->getValue();
+    }
+
+    /**
+     *
+     * @return string
+     */
+    public function getFirstName()
+    {
+        $firstNameElement = $this->findById($this->firstNameInputId);
+
+        if ($firstNameElement === null) {
+            throw new ElementNotFoundException(
+                "getFirstName:could not find element"
+            );
+        }
+
+        return $firstNameElement->getValue();
+    }
+
+    /**
+     *
+     * @return string
+     */
+    public function getLastName()
+    {
+        $lastNameElement = $this->findById($this->lastNameInputId);
+
+        if ($lastNameElement === null) {
+            throw new ElementNotFoundException(
+                "getLastName:could not find element"
+            );
+        }
+
+        return $lastNameElement->getValue();
+    }
+
+    /**
+     *
+     * @return string
+     */
+    public function getEmail()
+    {
+        $emailElement = $this->findById($this->emailInputId);
+
+        if ($emailElement === null) {
+            throw new ElementNotFoundException(
+                "getEmail:could not find element"
+            );
+        }
+
+        return $emailElement->getValue();
+    }
+
+    public function applyChanges()
+    {
+        $applyButton = $this->findById($this->applyButtonNormalId);
+
+        if ($applyButton === null) {
+            throw new ElementNotFoundException("could not find normal contact apply button");
+        }
+
+        if (!$applyButton->isVisible()) {
+            $applyButton = $this->findById($this->applyButtonMobileId);
+
+            if ($applyButton === null) {
+                throw new ElementNotFoundException("could not find mobile contact apply button");
+            }
+        }
+
+        if (!$applyButton->isVisible()) {
+            throw new ElementNotVisible("could not find any visible contact apply button");
+        }
+
+        $applyButton->click();
+    }
 }

--- a/tests/ui/features/lib/NewContactPage.php
+++ b/tests/ui/features/lib/NewContactPage.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * @copyright   2014 Mautic Contributors. All rights reserved
+ * @author      Mautic
+ *
+ * @link        http://mautic.org
+ *
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Page;
+
+class NewContactPage extends MauticPage
+{
+    /**
+     *
+     * @var string $path
+     */
+    protected $path = '/s/contacts/new';
+}


### PR DESCRIPTION
Issue #30 

1) Add separate jobs for the contacts suite - it will get bigger/longer
2) Refactor "redirected" step so we can say "I should be redirected..." or "I am redirected" equivalently. This makes some steps read better.
3) Code for opening, entering and applying new contact fields.

Note: after pressing "Apply" on a new contact, the user is actually taken to an edit contact page. That page has a different URL, referenced to the contact id number that was just allocated. But the fields have the same HTML "id"s. So we can check the resulting values with the same ``findById`` regardless of if we are in the process of adding a new contact or editing an existing contact.

When we come to add tests to edit and existing contact, there will need to be some page hierarchy refactoring so that stuff common to NewContactPage and EditContactPage goes in a page in-between.
